### PR TITLE
Add Docker Compose stack

### DIFF
--- a/deploy/compose.local.yml
+++ b/deploy/compose.local.yml
@@ -1,0 +1,29 @@
+# MLflow deployment with local SQLite database and local artifact storage in Docker volumes
+
+services:
+  mlflow:
+    build:
+      context: mlflow
+      dockerfile: Dockerfile
+    develop:
+      watch:
+        - path: mlflow
+          action: rebuild
+    ports:
+      - "5000:5000"
+    volumes:
+      - mlflow_artifacts:/mlartifacts
+      - mlflow_db:/mlruns
+    command:
+      - "mlflow"
+      - "server"
+      - "--host"
+      - "0.0.0.0"
+      - "--backend-store-uri"
+      - "sqlite:///mlruns/mlflow.db"
+      - "--default-artifact-root"
+      - "/mlartifacts"
+
+volumes:
+  mlflow_artifacts:
+  mlflow_db:

--- a/deploy/mlflow/Dockerfile
+++ b/deploy/mlflow/Dockerfile
@@ -1,0 +1,15 @@
+ARG UV_BASE_IMAGE_TAG=python3.13-bookworm-slim
+FROM ghcr.io/astral-sh/uv:${UV_BASE_IMAGE_TAG}
+
+ARG MLFLOW_VERSION=2.20.0
+
+ENV UV_LINK_MODE=copy
+ENV UV_SYSTEM_PYTHON=1
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install \
+    mlflow==${MLFLOW_VERSION} \
+    google-cloud-storage \
+    azure-storage-blob \
+    boto3 \
+    psycopg2-binary


### PR DESCRIPTION
This PR adds a Docker Compose stack containing the following tools for a reproducible local setup:

- MLflow (v2.20.0) with runs storage in an SQLite DB (Docker volume mounted to `/mlruns`) and artifact storage in a Docker volume (mounted to `/mlartifacts`)

As we move along, it might make sense to switch to cloud services for the artifact and run storage, so we can share state between team members (or alternatively deploy the stack on a a cloud VM).

## Usage

```console
$ docker compose -f deploy/compose.local.yml up
```