### PR TITLE
fix: Ravel storage options when constructing immutable input path

### DIFF
--- a/src/income_prediction/io_managers/lakefs.py
+++ b/src/income_prediction/io_managers/lakefs.py
@@ -30,7 +30,7 @@ class LakeFSParquetIOManager(dg.UPathIOManager):
                 raise RuntimeError("No canonical path found in metadata")
             return UPath(
                 canonical_uri,
-                storage_options=dict(self._base_path.storage_options),
+                **self._base_path.storage_options,
             )
         else:
             return super()._get_path(context)


### PR DESCRIPTION
Otherwise, `storage_options` is treated as a keyword argument, and the actual storage options (including lakeFS auth) is nested under the "storage_options" key, which leads to authentication errors.