### PR TITLE
Log train/test datasets with provenance to MLflow

### DIFF
--- a/src/income_prediction/assets/__init__.py
+++ b/src/income_prediction/assets/__init__.py
@@ -15,7 +15,7 @@ from income_prediction.utils.dagster import canonical_lakefs_uri_for_input
 
 from ..resources.configuration import Config, OptunaCVConfig
 from ..resources.mlflow_session import MlflowSession
-from ..utils.mlflow import LakeFSDatasetSource, log_fairness_metrics
+from ..utils.mlflow import log_fairness_metrics
 from .fairness import evaluate_fairness
 from .model import model_container as model_container
 from .monitoring import nannyml_container as nannyml_container
@@ -92,9 +92,8 @@ def optuna_search_xgb(
                 train_data,
                 name="train_data",
                 targets=CensusASECMetadata.TARGET,
-                source=LakeFSDatasetSource(
-                    lakefs_uri=canonical_lakefs_uri_for_input(context, "train_data"),
-                    server="localhost:8000",
+                source=canonical_lakefs_uri_for_input(
+                    context, "train_data", protocol="s3"
                 ),
             )
             mlflow.log_input(train_ds)
@@ -103,9 +102,8 @@ def optuna_search_xgb(
                 test_data,
                 name="test_data",
                 targets=CensusASECMetadata.TARGET,
-                source=LakeFSDatasetSource(
-                    lakefs_uri=canonical_lakefs_uri_for_input(context, "test_data"),
-                    server="localhost:8000",
+                source=canonical_lakefs_uri_for_input(
+                    context, "test_data", protocol="s3"
                 ),
             )
             mlflow.log_input(test_ds)

--- a/src/income_prediction/utils/dagster.py
+++ b/src/income_prediction/utils/dagster.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import dagster as dg
 
 SHORT_RUN_ID_LENGTH = 8
@@ -28,6 +30,7 @@ def extract_run_id(context: dg.AssetExecutionContext, short: bool = False) -> st
 def canonical_lakefs_uri_for_input(
     context: dg.AssetExecutionContext,
     input_name: str,
+    protocol: Literal["lakefs", "s3"] = "lakefs",
 ) -> str:
     """Return the canonical lakeFS URI for a given input asset (must be managed by a lakeFS I/O manager).
 
@@ -37,6 +40,8 @@ def canonical_lakefs_uri_for_input(
         Dagster asset execution context, providing information about the current run.
     input_name : str
         Name of the input asset
+    protocol : Literal["lakefs", "s3"], optional, default "lakefs"
+        Protocol to use in the URI (lakefs or S3)
 
     Returns
     -------
@@ -49,4 +54,8 @@ def canonical_lakefs_uri_for_input(
     metadata = ev.asset_materialization.metadata
     if "canonical_uri" not in metadata:
         raise ValueError("No canonical URI found in metadata")
-    return metadata.get("canonical_uri").value
+
+    uri = metadata.get("canonical_uri").value
+    if protocol == "s3":
+        uri = uri.replace("lakefs://", "s3://")
+    return uri

--- a/src/income_prediction/utils/mlflow.py
+++ b/src/income_prediction/utils/mlflow.py
@@ -1,51 +1,5 @@
-from typing import Any
-
 import mlflow
 from aif360.metrics import ClassificationMetric
-
-
-class LakeFSDatasetSource(mlflow.data.DatasetSource):
-    """A custom MLflow dataset source for datasets stored in lakeFS"""
-
-    def __init__(self, lakefs_uri: str, server: str):
-        super().__init__()
-        self.uri = lakefs_uri
-        self.server = server
-
-    @staticmethod
-    def _get_source_type() -> str:
-        return "lakefs"
-
-    def load(self) -> Any:
-        raise NotImplementedError()
-
-    @staticmethod
-    def _can_resolve(raw_source: Any) -> bool:
-        if raw_source is None:
-            return False
-        if isinstance(raw_source, str):
-            return raw_source.startswith("lakefs://")
-        return False
-
-    @classmethod
-    def _resolve(cls, raw_source: Any) -> "mlflow.data.DatasetSource":
-        return cls(raw_source)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "source_type": self._get_source_type(),
-            "lakefs_uri": self.uri,
-            "server": self.server,
-        }
-
-    @classmethod
-    def from_dict(cls, source_dict: dict[Any, Any]) -> "mlflow.data.DatasetSource":
-        source_type = source_dict["source_type"]
-        if source_type != cls._get_source_type():
-            raise ValueError(
-                f"Source type {source_dict['source_type']} does not match expected type {cls._get_source_type()}"
-            )
-        return cls(**source_dict)
 
 
 def start_mlflow_run(


### PR DESCRIPTION
This PR logs the train/test datasets to MLflow with S3 URIs pointing to the immutable lakeFS commit recorded in the materialization metadata for those assets.

Besides including valuable metadata about the datasets (schema, number of rows), this allows to easily cross-reference the data version of the repository with any given MLflow run.

![image](https://github.com/user-attachments/assets/bb0ddfd6-eb8e-4944-b962-dd6f99da45b9)
