### PR TITLE
docs: Add content to data governance conformity page

### DIFF
--- a/docs/conformity/data-governance.md
+++ b/docs/conformity/data-governance.md
@@ -11,7 +11,7 @@
         - |Art. 10(2)(e)|: Assessment of availability, quantity and suitability of the data sets
     - [Data Quality]:
         - |Art. 10(2)(c)|: Tracking data preparation steps like labelling, cleaning, imputation, enrichment;
-        - |Art. 10(3)|: Ensuring complete, error-free, and complete (for the respective application) training and testing data sets
+        - |Art. 10(3)|: Ensuring complete, error-free, and sufficiently representative (for the respective application) training and testing data sets
 
 
 ## Non-technical requirements
@@ -19,6 +19,9 @@
 Data governance measures serve two purposes in general in a high-risk AI use case: Transparency and accountability as well as quality assurance.
 The former is important for ensuring that no systematic biases in the data influence the behavior of the AI system, and to ensure reproducibility to allow ML engineers to identify issues in the training and evaluation process.
 The latter, meanwhile, is important to set up a rigorous performance evaluation ("benchmarking") process to ensure that an AI system performs as expected, and meets quality and safety standards.
+
+_Datasheets_ can be used to document training methodologies, metadata and relevant features and characteristics of the used datasets,
+as well as other non-technical aspects around the system such as the data provenance, how labels were obtained, and cleaning methods used.
 
 In practice, an organizational focus on thorough data management pays dividends in other areas of the machine learning lifecycle as well.
 Advantages of this include better awareness on different forms and versions of data, helping in crafting reproducible machine learning experiments, and higher availability of data assets to different teams, resulting in more efficient parallel workflows.
@@ -33,6 +36,7 @@ Data governance is linked to the following articles:
 
 - |Art. 12| (Record Keeping): For transparency on how high-risk AI systems perform in practice,
     and logging of events and input data over the course of the system's lifetime.
+- [Annex 4](https://artificialintelligenceact.eu/annex/4/) (Technical Documentation): To ensure the quality (especially correctness and completeness) of input data and to document engineering practices around the used data.
 
 <!-- Reference Links -->
 [Bias Mitigation]: ../engineering-practice/data-governance/bias-mitigation.md


### PR DESCRIPTION
Include a section on non-technical requirements and related articles, just as we did for the other articles.

Closes #69.