### PR TITLE
docs: Remove two TODOs in article mapping of engineering practices

### DIFF
--- a/docs/engineering-practice/containerization.md
+++ b/docs/engineering-practice/containerization.md
@@ -7,11 +7,11 @@ tags:
 
     --8<-- "docs/engineering-practice/_compliance-info-box.partial"
 
-    TODO: This list is incomplete
-
     - **|Art. 15|** (Accuracy, Robustness and Cybersecurity), in particular:
         - |Art. 15(1)|, containers provide a consistent and isolated runtime environment
         - |Art. 15(4)|, containers allow for redundant, reproducible and reliable application execution
+        - |Art. 15(5)|, containers provide an isolated runtime environment that limit the access of
+        attackers and unauthorized third parties to the underlying hardware
 
 ## Motivation
 

--- a/docs/engineering-practice/model-serving.md
+++ b/docs/engineering-practice/model-serving.md
@@ -9,9 +9,9 @@ tags:
 
     --8<-- "docs/engineering-practice/_compliance-info-box.partial"
 
-    TODO: Incomplete
-
-    - **|Art. 15|** (Accuracy, Robustness and Cybersecurity)
+    - **|Art. 15|** (Accuracy, Robustness and Cybersecurity), in particular:
+        - |Art. 15(4)|, model serving allows to run inference on models remotely, and to deploy models with redundancy
+        to make them more resilient.
 
 ## Motivation
 


### PR DESCRIPTION
While they have not been expanded a lot, both of them now contain another subpoint to give the reader a direction of where to look for additional information.

In the case of model serving, the current list is at one subparagraph of Art. 15, but more can be added in the future.