### PR TITLE
Analytics & privacy policy

### DIFF
--- a/docs/_scripts/feedback.js
+++ b/docs/_scripts/feedback.js
@@ -1,0 +1,33 @@
+document$.subscribe(function () {
+  const feedback = document.forms.feedback;
+  if (typeof feedback === "undefined") {
+    return;
+  }
+
+  // Show feedback text
+  feedback.hidden = false;
+
+  feedback.addEventListener("submit", function (ev) {
+    ev.preventDefault();
+
+    feedback.firstElementChild.disabled = true;
+
+    // Submit GTM page event
+    const dataLayer = window.dataLayer || [];
+    const page = document.location.pathname;
+    const data = ev.submitter.getAttribute("data-md-value");
+    dataLayer.push({
+      event: "feedback",
+      page: page,
+      feedback: data,
+    });
+
+    // Show note
+    const note = feedback.querySelector(
+      ".md-feedback__note [data-md-value='" + data + "']"
+    );
+    if (note) {
+      note.hidden = false;
+    }
+  });
+});

--- a/docs/_styles/extra.css
+++ b/docs/_styles/extra.css
@@ -217,3 +217,13 @@ table {
     U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
     U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
+/* Feedback title */
+.md-feedback__title {
+  font-weight: normal;
+  font-style: italic;
+}
+
+.md-feedback__list {
+  gap: 1rem;
+}

--- a/docs/_styles/extra.css
+++ b/docs/_styles/extra.css
@@ -218,7 +218,7 @@ table {
     U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
-/* Feedback title */
+/* Page feedback widget */
 .md-feedback__title {
   font-weight: normal;
   font-style: italic;

--- a/docs/_theme_overrides/partials/copyright.html
+++ b/docs/_theme_overrides/partials/copyright.html
@@ -9,10 +9,12 @@
       target="_blank"
       rel="noopener"
       >CC BY-SA 4.0 license</a
-    >, <a href="{{ 'imprint/' | url }}">Imprint</a>
+    >, <a href="{{ 'imprint/' | url }}">Imprint</a>,
+    <a href="{{ 'privacy/' | url }}">Privacy Policy</a>
   </p>
   <p>
-    The appliedAI Institute for Europe gGmbH is supported by the IPAI Foundation gGmbH.
+    The appliedAI Institute for Europe gGmbH is supported by the IPAI Foundation
+    gGmbH.
   </p>
 
   <div class="logo-container">

--- a/docs/_theme_overrides/partials/integrations/analytics/custom.html
+++ b/docs/_theme_overrides/partials/integrations/analytics/custom.html
@@ -1,3 +1,10 @@
+<!--
+  NOTE: Same-scheme URLs in this partial break local builds,
+  but are required to work around issues with the Privacy plugin.
+
+  Please don't replace them with `https:` URLs.
+-->
+
 <!-- Usercentrics -->
 <link rel="preconnect" href="//app.usercentrics.eu" />
 <link rel="preconnect" href="//api.usercentrics.eu" />
@@ -36,8 +43,9 @@
   });
 </script>
 
+<!-- NOTE: Make sure to use same-scheme URL (no `https:`) to prevent issues with privacy plugin -->
 <script
   async
-  src="https://www.googletagmanager.com/gtm.js?id={{ config.extra.analytics.gtmTagId }}"
+  src="//www.googletagmanager.com/gtm.js?id={{ config.extra.analytics.gtmTagId }}"
 ></script>
 <!-- End Google Tag Manager -->

--- a/docs/_theme_overrides/partials/integrations/analytics/custom.html
+++ b/docs/_theme_overrides/partials/integrations/analytics/custom.html
@@ -15,7 +15,7 @@
 />
 <script
   id="usercentrics-cmp"
-  src="https://app.usercentrics.eu/browser-ui/latest/loader.js"
+  src="//app.usercentrics.eu/browser-ui/latest/loader.js"
   data-settings-id="{{ config.extra.analytics.usercentricsSettingsId }}"
   async
 ></script>

--- a/docs/_theme_overrides/partials/integrations/analytics/custom.html
+++ b/docs/_theme_overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,43 @@
+<!-- Usercentrics -->
+<link rel="preconnect" href="//app.usercentrics.eu" />
+<link rel="preconnect" href="//api.usercentrics.eu" />
+<link
+  rel="preload"
+  href="//app.usercentrics.eu/browser-ui/latest/loader.js"
+  as="script"
+/>
+<script
+  id="usercentrics-cmp"
+  src="https://app.usercentrics.eu/browser-ui/latest/loader.js"
+  data-settings-id="{{ config.extra.analytics.usercentricsSettingsId }}"
+  async
+></script>
+<!-- End Usercentrics -->
+
+<!-- Google Tag Manager (noscript) -->
+<noscript
+  ><iframe
+    src="https://www.googletagmanager.com/ns.html?id={{ config.extra.analytics.gtmTagId }}"
+    height="0"
+    width="0"
+    style="display: none; visibility: hidden"
+  ></iframe
+></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<!-- Google Tag Manager -->
+<script>
+  window["dataLayer"] = window["dataLayer"] || [];
+  window["dataLayer"].push({
+    js: new Date(),
+    config: "{{ config.extra.analytics.gtmTagId }}",
+    "gtm.start": new Date().getTime(),
+    event: "gtm.js",
+  });
+</script>
+
+<script
+  async
+  src="https://www.googletagmanager.com/gtm.js?id={{ config.extra.analytics.gtmTagId }}"
+></script>
+<!-- End Google Tag Manager -->

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,5 @@
+# Privacy Policy
+
+This web site is part of the appliedAI Institute for Europe gGmbH web offering. Please refer to the [Privacy Policy](https://www.appliedai-institute.de/en/privacy-policy) of the appliedAI Institute for Europe gGmbH, which also applies to this web site.
+
+You may customize your privacy and consent settings by clicking on the following link: [Privacy Settings](<javascript:UC_UI.showSecondLayer()>)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,8 +89,6 @@ plugins:
       canonical_version: latest
   - meta
   - privacy:
-      # Only enable in CI/CD builds (GTM assets downloaded during build, which are blocked by local ad blockers)
-      assets: !ENV [CI, false]
   - search:
   - tags
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,9 @@ nav:
       - conformity/human-oversight.md
       - conformity/accuracy-robustness-cybersecurity.md
 
-not_in_nav: imprint.md
+not_in_nav: |
+  /imprint.md
+  /privacy.md
 
 plugins:
   - callouts
@@ -86,7 +88,9 @@ plugins:
   - mike:
       canonical_version: latest
   - meta
-  - privacy
+  - privacy:
+      # Only enable in CI/CD builds (GTM assets downloaded during build, which are blocked by local ad blockers)
+      assets: !ENV [CI, false]
   - search:
   - tags
 
@@ -164,6 +168,26 @@ extra:
   version:
     provider: mike
     default: latest
+  analytics:
+    provider: custom
+    # appliedAI Institute Google Tag Manager and UserCentrics
+    gtmTagId: GTM-PG5277D
+    usercentricsSettingsId: tKPkHjSNKKwpNH
+    feedback:
+      title: "Was this page helpful?"
+      ratings:
+        - icon: material/thumb-up-outline
+          name: This page was helpful
+          data: good
+          note: >-
+            Thanks for your feedback!
+        - icon: material/thumb-down-outline
+          name: This page could be improved
+          data: bad
+          note: >-
+            Thanks for your feedback! If you would like to help us improve this page, please consider
+            creating a ticket in our <a href="https://github.com/aai-institute/practical-ai-act/issues" target="_blank" rel="noopener">issue tracker</a>.
+
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/aai-institute/twai-pipeline
@@ -178,3 +202,4 @@ extra_css:
 extra_javascript:
   # Fix for problems with privacy plugin and site_url set (see https://github.com/squidfunk/mkdocs-material/issues/3742)
   - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - _scripts/feedback.js


### PR DESCRIPTION
This PR adds analytics tracking:

- UserCentrics for consent management
- Google Tag Manager for analytics
- Custom GTM event `feedback` for page feedback collection

Also, a privacy policy stub page has been added that forwards the user to the Institute's privacy policy and gives them the possibility to customize their consent settings (through UC).

## Page feedback collection

In order to properly collect analytics data (and get it visible inside GA), we need to follow the steps outlined in the [Site Analytics setup guide](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/):

- Define custom event `feedback` in GA
- Set up tag for `feedback` event in GTM, custom data-layer variable `feedback`, forward that data to GA
- Optionally: enable enhanced measurements on the GA4 data stream for site search analytics